### PR TITLE
Improve schema handling

### DIFF
--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -378,9 +378,14 @@ Validation with JSON Schema
 ---------------------------
 
 You can tell the processor to look for a JSON schema file and validate
-the current YAML file by adding a ``#!<SCHEMA-URI>`` to the beginning
-of the YAML file. The ``SCHEMA-URI`` is a string pointing to the location
-of a JSON schema file. Some simple assumptions apply:
+the current YAML file by adding a schema association line to the beginning
+of the YAML file, which can be one of:
+
+ - ``#!<SCHEMA-URI>``
+ - ``# yaml-language-server: $schema=<SCHEMA-URI>``
+
+Where the ``SCHEMA-URI`` is a string pointing to the location of a JSON schema
+file.  Some simple assumptions apply:
 
  - If ``SCHEMA-URI`` is a normal URI with a leading scheme,
    e.g., ``https://``, it is used as-is.

--- a/docs/schema-process.rst
+++ b/docs/schema-process.rst
@@ -47,8 +47,8 @@ to tell it where to split up the schema in the syntax:
 .. code-block:: json
 
    {
-       "OUTPUT-ROOT-SCHEMA-FILENAME": "",
-       "OUTPUT-SUB-SCHEMA-FILENAME-1": "JMESPATH-1",
+       "": "OUTPUT-ROOT-SCHEMA-FILENAME",
+       "JMESPATH-1": "OUTPUT-SUB-SCHEMA-FILENAME-1",
        "And so on": "..."
    }
 
@@ -61,8 +61,8 @@ subschemas. In the example above, we can use the setting:
 .. code-block:: json
 
    {
-       "hello.schema.json": "",
-       "hello-location.schema.json": "properties.hello.items"
+       "": "hello.schema.json",
+       "properties.hello.items": "hello-location.schema.json"
    }
 
 The resulting ``hello.schema.json`` will look like this,
@@ -76,18 +76,7 @@ which can be used to validate both ``hello.yaml`` and ``hello-root.yaml``.
                "items": {
                    "oneOf": [
                        {"$ref": "hello-location.schema.json"},
-                       {
-                           "properties": {
-                               "INCLUDE": {
-                                   "type": "string"
-                               },
-                               "QUERY": {
-                                   "type": "string"
-                               }
-                           },
-                           "required": ["INCLUDE"],
-                           "type": "string"
-                       }
+                       {"$ref": "yp-include.schema.json"},
                    ]
                },
                "type": "array"
@@ -119,3 +108,23 @@ which can be used to validate ``earth.yaml`` and ``mars.yaml``:
        "required": ["location", "targets"],
        "type": "object"
    }
+
+You may notice a file called ``yp-include.schema.json`` in the current
+working directory. This is the sub-schema for the syntax related to the
+``INCLUDE`` functionality described in :doc:`data-process`. The file is
+referenced by ``hello.schema.json`` in the example above.
+
+The default output location of the file is ``yp-include.schema.json``, but you
+can change it by adding an entry for ``$ref.yp-include.schema.json`` in the
+configuration file. Using the above example configuration file, you can do:
+
+.. code-block:: json
+
+   {
+       "": "hello.schema.json",
+       "$ref:yp-include.schema.json": "yp-include.schema.json",
+       "properties.hello.items": "hello-location.schema.json"
+   }
+
+(Note: ``$ref:yp-include.schema.json`` is a special entry. It is not a valid
+JMESPath syntax.)

--- a/src/yamlprocessor/dataprocess.py
+++ b/src/yamlprocessor/dataprocess.py
@@ -10,9 +10,8 @@ value of corresponding (environment) variable.
 For each string value with ``$YP_TIME_*`` or ``${YP_TIME_*}`` syntax,
 substitute with value of corresponding date-time string.
 
-Validate against specified JSON schema if root file starts with a
-``#!<SCHEMA-URI>`` line.
-
+Validate against specified JSON schema if root file starts with either
+``#!<SCHEMA-URI>`` or ``# yaml-language-server: $schema=<SCHEMA-URI>`` line.
 """
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
@@ -381,7 +380,7 @@ class DataProcessor:
 
     @staticmethod
     def load_file_schema(filename: str) -> object:
-        """Load schema location from #! line of file.
+        """Load schema location from the schema association line of file.
 
         :param filename: name of file to load schema location.
         :return: a string containing the location of the schema or None.
@@ -391,8 +390,9 @@ class DataProcessor:
         else:
             with open(filename) as file_:
                 line = file_.readline()
-        if line.startswith('#!'):
-            return line[2:].strip()
+        for prefix in ('#!', '# yaml-language-server: $schema='):
+            if line.startswith(prefix):
+                return line[len(prefix):].strip()
         else:
             return None
 

--- a/src/yamlprocessor/schemaprocess.py
+++ b/src/yamlprocessor/schemaprocess.py
@@ -46,6 +46,7 @@ INCLUDE_SCHEMA = {
     'required': [DataProcessor.INCLUDE_KEY],
     'type': 'object',
 }
+INCLUDE_SCHEMA_FILENAME = 'yp-include.schema.json'
 
 
 def schema_process(schema_filename: str, config_filename: str) -> None:
@@ -58,7 +59,11 @@ def schema_process(schema_filename: str, config_filename: str) -> None:
     schema = json.load(open(schema_filename))
     subschemas = {}  # {filerelname: subschema, ...}
     schema_filebasename = '0-{}'.format(os.path.basename(schema_filename))
-    for filerelname, pathstr in json.load(open(config_filename)).items():
+    config = json.load(open(config_filename))
+    # Special entry for include schema filename
+    include_schema_filename = config.pop(
+        '$ref:yp-include.schema.json', INCLUDE_SCHEMA_FILENAME)
+    for pathstr, filerelname in config.items():
         pathstr = pathstr.strip()
         if not pathstr:
             schema_filebasename = filerelname
@@ -81,13 +86,18 @@ def schema_process(schema_filename: str, config_filename: str) -> None:
     for filerelname, subschema in subschemas.items():
         subschema.clear()
         subschema.update({
-            'oneOf': [{'$ref': filerelname}, INCLUDE_SCHEMA],
+            'oneOf': [
+                {'$ref': filerelname},
+                {'$ref': include_schema_filename},
+            ],
         })
 
     # Dump subschemas from copies, because original has been modified in place.
     for filerelname, subschema in subschema_copies.items():
         with open(filerelname, 'w') as subschema_file:
             json.dump(subschema, subschema_file, **JSON_DUMP_CONFIG)
+    with open(include_schema_filename, 'w') as include_schema_file:
+        json.dump(INCLUDE_SCHEMA, include_schema_file, **JSON_DUMP_CONFIG)
     with open(schema_filebasename, 'w') as schema_file:
         json.dump(schema, schema_file, **JSON_DUMP_CONFIG)
 

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -363,25 +363,26 @@ def test_main_validate_1(tmp_path, capsys):
         json.dump(schema, schemafile)
     outfilename = tmp_path / 'b.yaml'
     infilename = tmp_path / 'a.yaml'
-    # Schema specified as an absolute file system path
-    with infilename.open('w') as infile:
-        infile.write(f'#!{schemafilename}\n')
-        yaml.dump({'hello': 'earth'}, infile)
-    main([str(infilename), str(outfilename)])
-    captured = capsys.readouterr()
-    assert f'[INFO] ok {outfilename}' in captured.err.splitlines()
-    # Schema specified as a file:// URL
-    with infilename.open('w') as infile:
-        infile.write(f'#!file://{schemafilename}\n')
-        yaml.dump({'hello': 'earth'}, infile)
-    main([str(infilename), str(outfilename)])
-    captured = capsys.readouterr()
-    assert f'[INFO] ok {outfilename}' in captured.err.splitlines()
-    # Schema specified as a relative path, with schema prefix
-    with infilename.open('w') as infile:
-        infile.write('#!hello.schema.json\n')
-        yaml.dump({'hello': 'earth'}, infile)
-    schema_prefix = f'--schema-prefix=file://{tmp_path}/'
-    main([schema_prefix, str(infilename), str(outfilename)])
-    captured = capsys.readouterr()
-    assert f'[INFO] ok {outfilename}' in captured.err.splitlines()
+    for prefix in ('#!', '# yaml-language-server: $schema='):
+        # Schema specified as an absolute file system path
+        with infilename.open('w') as infile:
+            infile.write(f'{prefix}{schemafilename}\n')
+            yaml.dump({'hello': 'earth'}, infile)
+        main([str(infilename), str(outfilename)])
+        captured = capsys.readouterr()
+        assert f'[INFO] ok {outfilename}' in captured.err.splitlines()
+        # Schema specified as a file:// URL
+        with infilename.open('w') as infile:
+            infile.write(f'{prefix}file://{schemafilename}\n')
+            yaml.dump({'hello': 'earth'}, infile)
+        main([str(infilename), str(outfilename)])
+        captured = capsys.readouterr()
+        assert f'[INFO] ok {outfilename}' in captured.err.splitlines()
+        # Schema specified as a relative path, with schema prefix
+        with infilename.open('w') as infile:
+            infile.write(f'{prefix}hello.schema.json\n')
+            yaml.dump({'hello': 'earth'}, infile)
+        schema_prefix = f'--schema-prefix=file://{tmp_path}/'
+        main([schema_prefix, str(infilename), str(outfilename)])
+        captured = capsys.readouterr()
+        assert f'[INFO] ok {outfilename}' in captured.err.splitlines()

--- a/src/yamlprocessor/tests/test_schemaprocess.py
+++ b/src/yamlprocessor/tests/test_schemaprocess.py
@@ -1,9 +1,27 @@
 import json
 
-from ..schemaprocess import INCLUDE_SCHEMA, main
+import jsonschema
+
+from ..schemaprocess import INCLUDE_SCHEMA, INCLUDE_SCHEMA_FILENAME, main
 
 
-def test_main_1(monkeypatch, tmp_path):
+SAMPLE_TESTING = [-1, 0, 1]
+SAMPLE_MAIN_ONE = {'testing': SAMPLE_TESTING}
+SAMPLE_MAIN_ONE_INC = {'testing': {'INCLUDE': 'test-data.yaml'}}
+SAMPLE_EXAMINING_NAME_ONE = 'one'
+SAMPLE_EXAMINING = [
+    {'name': {'INCLUDE': 'batch-xxx-name.txt'}, 'batch': 1234},
+    {'name': 'two', 'batch': 5678},
+]
+SAMPLE_MAIN_THREE = {'testing': SAMPLE_TESTING, 'examining': SAMPLE_EXAMINING}
+SAMPLE_MAIN_THREE_INC = {
+    'testing': SAMPLE_TESTING,
+    'examining': {'INCLUDE': 'exam-data.yaml'},
+}
+
+
+def test_main_one(monkeypatch, tmp_path):
+    """Test with one include entry."""
     schema = {
         'additionalProperties': False,
         'properties': {
@@ -21,33 +39,57 @@ def test_main_1(monkeypatch, tmp_path):
     with schema_filename.open('w') as schema_file:
         json.dump(schema, schema_file)
     config = {
-        'schema-0.json': '',
-        'schema-1.json': 'properties.testing.items',
+        '': 'schema-root.json',
+        'properties.testing': 'schema-a.json',
     }
     config_filename = tmp_path / 'config.json'
     with config_filename.open('w') as config_file:
         json.dump(config, config_file)
     monkeypatch.chdir(tmp_path)
     main([str(schema_filename), str(config_filename)])
-    with (tmp_path / 'schema-0.json').open() as schema_0_file:
-        assert json.load(schema_0_file) == {
+    with (tmp_path / 'schema-root.json').open() as schema_root_file:
+        assert json.load(schema_root_file) == {
             'additionalProperties': False,
             'properties': {
                 'testing': {
-                    'items': {
-                        'oneOf': [{'$ref': 'schema-1.json'}, INCLUDE_SCHEMA],
-                    },
-                    'type': 'array',
+                    'oneOf': [
+                        {'$ref': 'schema-a.json'},
+                        {'$ref': INCLUDE_SCHEMA_FILENAME},
+                    ],
                 },
             },
             'required': ['testing'],
             'type': 'object',
         }
-    with (tmp_path / 'schema-1.json').open() as schema_1_file:
-        assert json.load(schema_1_file) == {'type': 'integer'}
+    with (tmp_path / 'schema-a.json').open() as schema_a_file:
+        assert json.load(schema_a_file) == {
+            'items': {'type': 'integer'},
+            'type': 'array',
+        }
+    with (tmp_path / INCLUDE_SCHEMA_FILENAME).open() as include_schema_file:
+        assert json.load(include_schema_file) == INCLUDE_SCHEMA
+
+    # See if schemas can validate data or not
+    for schema_filename, sample_data in (
+        ('schema-root.json', SAMPLE_MAIN_ONE),
+        ('schema-root.json', SAMPLE_MAIN_ONE_INC),
+        ('schema-a.json', SAMPLE_TESTING),
+    ):
+        try:
+            jsonschema.validate(
+                schema={
+                    '$ref': (tmp_path / schema_filename).absolute().as_uri()
+                },
+                instance=sample_data,
+            )
+        except jsonschema.exceptions.ValidationError as exc:
+            assert False, f"{schema_filename} does not validate data:\n{exc}"
+        else:
+            assert True, f"{schema_filename} works OK with data"
 
 
-def test_main_3(monkeypatch, tmp_path):
+def test_main_three(monkeypatch, tmp_path):
+    """Test with three include entries, nested."""
     schema = {
         'additionalProperties': False,
         'properties': {
@@ -80,50 +122,81 @@ def test_main_3(monkeypatch, tmp_path):
     with schema_filename.open('w') as schema_file:
         json.dump(schema, schema_file)
     config = {
-        'schema-0.json': '',
-        'schema-1.json': 'properties.testing.items',
-        'schema-2.json': 'properties.examining.items',
-        'schema-3.json': 'properties.examining.items.properties.name',
+        '': 'schema-root.json',
+        'properties.testing': 'schema-a.json',
+        'properties.examining': 'schema-b.json',
+        'properties.examining.items.properties.name': 'schema-c.json',
     }
     config_filename = tmp_path / 'config.json'
     with config_filename.open('w') as config_file:
         json.dump(config, config_file)
     monkeypatch.chdir(tmp_path)
     main([str(schema_filename), str(config_filename)])
-    with (tmp_path / 'schema-0.json').open() as schema_0_file:
-        assert json.load(schema_0_file) == {
+    with (tmp_path / 'schema-root.json').open() as schema_root_file:
+        assert json.load(schema_root_file) == {
             'additionalProperties': False,
             'properties': {
                 'testing': {
-                    'items': {
-                        'oneOf': [{'$ref': 'schema-1.json'}, INCLUDE_SCHEMA],
-                    },
-                    'type': 'array',
+                    'oneOf': [
+                        {'$ref': 'schema-a.json'},
+                        {'$ref': INCLUDE_SCHEMA_FILENAME},
+                    ],
                 },
                 'examining': {
-                    'items': {
-                        'oneOf': [{'$ref': 'schema-2.json'}, INCLUDE_SCHEMA],
-                    },
-                    'type': 'array',
+                    'oneOf': [
+                        {'$ref': 'schema-b.json'},
+                        {'$ref': INCLUDE_SCHEMA_FILENAME},
+                    ],
                 },
             },
             'required': ['testing', 'examining'],
             'type': 'object',
         }
-    with (tmp_path / 'schema-1.json').open() as schema_1_file:
-        assert json.load(schema_1_file) == {'type': 'integer'}
-    with (tmp_path / 'schema-2.json').open() as schema_2_file:
-        assert json.load(schema_2_file) == {
-            'properties': {
-                'batch': {
-                    'type': 'integer',
-                },
-                'name': {
-                    'oneOf': [{'$ref': 'schema-3.json'}, INCLUDE_SCHEMA],
-                },
-            },
-            'type': 'object',
-            'required': ['batch', 'name'],
+    with (tmp_path / 'schema-a.json').open() as schema_a_file:
+        assert json.load(schema_a_file) == {
+            'items': {'type': 'integer'},
+            'type': 'array',
         }
-    with (tmp_path / 'schema-3.json').open() as schema_3_file:
-        assert json.load(schema_3_file) == {'type': 'string'}
+    with (tmp_path / 'schema-b.json').open() as schema_b_file:
+        assert json.load(schema_b_file) == {
+            'items': {
+                'properties': {
+                    'batch': {
+                        'type': 'integer',
+                    },
+                    'name': {
+                        'oneOf': [
+                            {'$ref': 'schema-c.json'},
+                            {'$ref': INCLUDE_SCHEMA_FILENAME},
+                        ],
+                    },
+                },
+                'type': 'object',
+                'required': ['batch', 'name'],
+            },
+            'type': 'array',
+        }
+    with (tmp_path / 'schema-c.json').open() as schema_c_file:
+        assert json.load(schema_c_file) == {'type': 'string'}
+    with (tmp_path / INCLUDE_SCHEMA_FILENAME).open() as include_schema_file:
+        assert json.load(include_schema_file) == INCLUDE_SCHEMA
+
+    # See if schemas can validate data or not
+    for schema_filename, sample_data in (
+        ('schema-root.json', SAMPLE_MAIN_THREE),
+        ('schema-root.json', SAMPLE_MAIN_THREE_INC),
+        ('schema-a.json', SAMPLE_TESTING),
+        ('schema-b.json', SAMPLE_EXAMINING),
+        ('schema-c.json', SAMPLE_EXAMINING_NAME_ONE),
+    ):
+        try:
+            jsonschema.validate(
+                schema={
+                    '$ref': (tmp_path / schema_filename).absolute().as_uri()
+                },
+                instance=sample_data,
+            )
+        except jsonschema.exceptions.ValidationError as exc:
+            assert False, f"{schema_filename} does not validate data:\n{exc}"
+        else:
+            assert True, f"{schema_filename} works OK with data"


### PR DESCRIPTION
Validation to recognise YAML Language Server's schema association
syntax.

Sub-schema generation logic to put INCLUDE syntax sub-schema in its own
file to avoid unnecessary duplication.

I have reversed the yp-schema's configuration key:value for better flexibility.

Add schema validation tests for yp-schema's unit tests.

Close #4.