### PR TITLE
Value substitution supports cast to int/float/bool

### DIFF
--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -391,6 +391,10 @@ will give:
    version: 4
    speed: 3.14
 
+Note: The processor casts integers and floats using Python's built-in
+:py:func:`int` and :py:func:`float` functions. The exact behaviour may change
+with the version of Python you are using.
+
 However, a single value can only have a single substitution with a cast:
 
 .. code-block:: yaml

--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -358,9 +358,10 @@ reference time.
 Cast Value Variable Substitution
 --------------------------------
 
-For non-string scalar values, i.e. integers, floats and booleans, the YAML
-processor utility supports casting the value to the correct type before using
-it for substitution:
+Environment variables are strings by nature, but YAML scalars can be numbers or
+booleans. Therefore, for non-string scalar values, i.e. integers, floats and
+booleans, the YAML processor utility supports casting the value to the correct
+type before using it for substitution:
 
 ``${NAME.int}``
     Cast value of ``NAME`` to an integer.
@@ -369,7 +370,10 @@ it for substitution:
     Cast value of ``NAME`` to a float.
 
 ``${NAME.bool}``
-    Cast value of ``NAME`` to a boolean.
+    Cast value of ``NAME`` to a boolean. Value of ``NAME`` must be one of
+    the supported case insensitive strings: ``yes``, ``true`` and ``1`` will
+    cast to the boolean ``true``, and ``no``, ``false`` and ``0`` will be cast
+    to the boolean ``false``.
 
 For example, suppose we have ``main.yaml``:
 

--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -355,6 +355,47 @@ YP_TIME_REF=whatever``, then you will get the value ``whatever`` instead of the
 reference time.
 
 
+Cast Value Variable Substitution
+--------------------------------
+
+For non-string scalar values, i.e. integers, floats and booleans, the YAML
+processor utility supports casting the value to the correct type before using
+it for substitution:
+
+``${NAME.int}``
+    Cast value of ``NAME`` to an integer.
+
+``${NAME.float}``
+    Cast value of ``NAME`` to a float.
+
+``${NAME.bool}``
+    Cast value of ``NAME`` to a boolean.
+
+For example, suppose we have ``main.yaml``:
+
+.. code-block:: yaml
+
+   version: ${ITEM_VERSION.int}
+   speed: ${ITEM_SPEED.float}
+
+Running
+:program:`yp-data -D ITEM_VERSION=4 -D ITEM_SPEED=3.14 main.yaml <yp-data>`
+will give:
+
+.. code-block:: yaml
+
+   version: 4
+   speed: 3.14
+
+However, a single value can only have a single substitution with a cast:
+
+.. code-block:: yaml
+
+   - ${NUM2.int}             # good
+   - xyz${NUM2.int}          # bad
+   - ${NUM2.int}${NUM3.int}  # bad
+
+
 Turn Off Processing
 -------------------
 

--- a/src/yamlprocessor/dataprocess.py
+++ b/src/yamlprocessor/dataprocess.py
@@ -456,9 +456,18 @@ class DataProcessor:
                             substitute = int(substitute)
                         elif groups['cast'] == '.float':
                             substitute = float(substitute)
-                        elif groups['cast'] == '.bool':
-                            substitute = (
-                                substitute.lower() not in ('0', 'false', 'no'))
+                        elif (
+                            groups['cast'] == '.bool'
+                            and substitute.lower() in ('0', 'false', 'no')
+                        ):
+                            substitute = False
+                        elif (
+                            groups['cast'] == '.bool'
+                            and substitute.lower() in ('1', 'true', 'yes')
+                        ):
+                            substitute = True
+                        else:
+                            raise ValueError
                     except ValueError:
                         raise ValueError(
                             f'{item}: bad substitution value: {substitute}')

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -158,7 +158,7 @@ def test_process_variable_5():
         'PI': '3.14',
         'CHARGE': '-1.6E-19',
         'LOWER_TRUE': 'true',
-        'UPPER_TRUE': 'true',
+        'UPPER_TRUE': 'TRUE',
         'YES': 'yes',
         'ONE': '1',
         'LOWER_FALSE': 'false',

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -147,6 +147,47 @@ def test_process_variable_4():
             == '2022-02-20T22:02:00' + out3)
 
 
+def test_process_variable_5():
+    """Test DataProcessor.process_variable int, float, bool substitution."""
+    processor = DataProcessor()
+    processor.variable_map.clear()
+    # Variables for substitution
+    processor.variable_map.update({
+        'N_PLANETS': '8',
+        'COLD': '-10',
+        'PI': '3.14',
+        'CHARGE': '-1.6E-19',
+        'GOOD': 'true',
+        'LOWER_FALSE': 'false',
+        'UPPER_FALSE': 'FALSE',
+        'NO': 'no',
+        'ZERO': '0',
+        'STRING': 'string',
+    })
+    # Good usages
+    assert processor.process_variable(r'${N_PLANETS.int}') == 8
+    assert processor.process_variable(r'${COLD.int}') == -10
+    assert processor.process_variable(r'${PI.float}') == 3.14
+    assert processor.process_variable(r'${CHARGE.float}') == -1.6E-19
+    assert processor.process_variable(r'${GOOD.bool}') is True
+    for name in ('LOWER_FALSE', 'UPPER_FALSE', 'NO', 'ZERO'):
+        assert processor.process_variable(r"${" + name + r".bool}") is False
+    # Bad usages
+    with pytest.raises(ValueError) as excinfo:
+        processor.process_variable(r'Not ${PI.float}.')
+        assert (
+            str(excinfo.value)
+            == 'Not ${PI.float}.: bad substitution expression'
+        )
+    for cast in ('.int', '.float'):
+        item = r'${STRING' + cast + r'}'
+        with pytest.raises(ValueError) as excinfo:
+            processor.process_variable(item)
+            assert (
+                str(excinfo.value) == item + ': bad substitution value: string'
+            )
+
+
 def test_main_0(tmp_path):
     """Test main, basic."""
     data = {'testing': [1, 2, 3]}

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -157,7 +157,10 @@ def test_process_variable_5():
         'COLD': '-10',
         'PI': '3.14',
         'CHARGE': '-1.6E-19',
-        'GOOD': 'true',
+        'LOWER_TRUE': 'true',
+        'UPPER_TRUE': 'true',
+        'YES': 'yes',
+        'ONE': '1',
         'LOWER_FALSE': 'false',
         'UPPER_FALSE': 'FALSE',
         'NO': 'no',
@@ -169,7 +172,8 @@ def test_process_variable_5():
     assert processor.process_variable(r'${COLD.int}') == -10
     assert processor.process_variable(r'${PI.float}') == 3.14
     assert processor.process_variable(r'${CHARGE.float}') == -1.6E-19
-    assert processor.process_variable(r'${GOOD.bool}') is True
+    for name in ('LOWER_TRUE', 'UPPER_TRUE', 'YES', 'ONE'):
+        assert processor.process_variable(r"${" + name + r".bool}") is True
     for name in ('LOWER_FALSE', 'UPPER_FALSE', 'NO', 'ZERO'):
         assert processor.process_variable(r"${" + name + r".bool}") is False
     # Bad usages
@@ -179,7 +183,7 @@ def test_process_variable_5():
             str(excinfo.value)
             == 'Not ${PI.float}.: bad substitution expression'
         )
-    for cast in ('.int', '.float'):
+    for cast in ('.int', '.float', '.bool'):
         item = r'${STRING' + cast + r'}'
         with pytest.raises(ValueError) as excinfo:
             processor.process_variable(item)


### PR DESCRIPTION
Support value substitution syntax `${NAME.int}`, `${NAME.float}` and `${NAME.bool}` to cast whole value into integer, float and boolean respectively. Close #3.