### PR TITLE
Support include from values from Python dict

### DIFF
--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -61,6 +61,36 @@ for it from these locations in order:
    - In the :py:attr:`.include_paths` (list) attribute of the relevant
      :py:class:`yamlprocessor.dataprocess.DataProcessor` instance.
 
+(In Python only.) The :py:attr:`.include_dict` (dict) attribute of the relevant
+:py:class:`yamlprocessor.dataprocess.DataProcessor` instance can be populated
+with keys to match ``INCLUDE`` names. On a matching key, the value will be
+inserted as if it were the content loaded from an include file. The processor
+will always attempt to find a match from this attribute before looking for
+matching include files from the file system. Suppose we use the following
+Python logic with the above files:
+
+.. code-block:: python
+
+   from yamlprocessor.dataprocess import DataProcessor
+   # ...
+   processor = DataProcessor()
+   processor.include_dict.update({
+       'earth.yaml': {'location': 'earth', 'targets': ['dinosaur']},
+   })
+   processor.process_data('hello.yaml')
+
+We'll get:
+
+.. code-block:: yaml
+
+   hello:
+     - location: earth
+       targets:
+         - dinosaur
+     - location: mars
+       targets:
+         - martian
+
 LIMITATIONS
 
  - YAML anchors/references will only work within files, so an include file will

--- a/src/yamlprocessor/dataprocess.py
+++ b/src/yamlprocessor/dataprocess.py
@@ -166,6 +166,11 @@ class DataProcessor:
 
        Turn on/off variable substitution.
 
+    .. py:attribute:: .include_dict
+       :type: dict
+
+       Dictonary for values that can be substituted for include.
+
     .. py:attribute:: .include_paths
        :type: list
 
@@ -247,6 +252,7 @@ class DataProcessor:
             item
             for item in os.getenv('YP_INCLUDE_PATH', '').split(os.pathsep)
             if item)
+        self.include_dict = {}
         self.schema_prefix = os.getenv('YP_SCHEMA_PREFIX')
         self.time_formats = {'': '%FT%T%:z'}
         self.time_now = datetime.now(tzlocal())  # assume application is fast
@@ -354,9 +360,14 @@ class DataProcessor:
         ):
             include_filename = self.process_variable(
                 value[self.INCLUDE_KEY])
-            filename = self.get_filename(include_filename, parent_filenames)
+            try:
+                loaded_value = self.include_dict[include_filename]
+                filename = include_filename
+            except KeyError:
+                filename = self.get_filename(
+                    include_filename, parent_filenames)
+                loaded_value = self.load_file(filename)
             parent_filenames.append(filename)
-            loaded_value = self.load_file(filename)
             if self.VARIABLES_KEY in value:
                 variable_map.update(value[self.VARIABLES_KEY])
             if self.QUERY_KEY in value:

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -386,3 +386,24 @@ def test_main_validate_1(tmp_path, capsys):
         main([schema_prefix, str(infilename), str(outfilename)])
         captured = capsys.readouterr()
         assert f'[INFO] ok {outfilename}' in captured.err.splitlines()
+
+
+def test_process_data_1(tmp_path):
+    """Test DataProcessor.process_data, with DataProcessor.include_dict."""
+    data = {'testing': ['one', 2, {3: [3.1, 3.14]}]}
+    data_0 = {'testing': [{'INCLUDE': '1.yaml'}, 2, {'INCLUDE': '3.yaml'}]}
+    infilename = tmp_path / 'a.yaml'
+    with infilename.open('w') as infile:
+        yaml.dump(data_0, infile)
+    with (tmp_path / '1.yaml').open('w') as infile_1:
+        yaml.dump(1, infile_1)
+    with (tmp_path / '3.yaml').open('w') as infile_3:
+        yaml.dump({3: {'INCLUDE': '3x.yaml'}}, infile_3)
+    processor = DataProcessor()
+    processor.include_dict.update({
+        '1.yaml': 'one',
+        '3x.yaml': [3.1, 3.14],
+    })
+    outfilename = tmp_path / 'b.yaml'
+    processor.process_data(str(infilename), str(outfilename))
+    assert yaml.safe_load(outfilename.open()) == data

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -388,21 +388,23 @@ def test_main_validate_1(tmp_path, capsys):
         assert f'[INFO] ok {outfilename}' in captured.err.splitlines()
 
 
-def test_process_data_1(tmp_path):
+def test_process_data_include_dict(tmp_path):
     """Test DataProcessor.process_data, with DataProcessor.include_dict."""
     data = {'testing': ['one', 2, {3: [3.1, 3.14]}]}
     data_0 = {'testing': [{'INCLUDE': '1.yaml'}, 2, {'INCLUDE': '3.yaml'}]}
     infilename = tmp_path / 'a.yaml'
     with infilename.open('w') as infile:
         yaml.dump(data_0, infile)
+    # This one gets overriden.
     with (tmp_path / '1.yaml').open('w') as infile_1:
         yaml.dump(1, infile_1)
+    # This one is used.
     with (tmp_path / '3.yaml').open('w') as infile_3:
         yaml.dump({3: {'INCLUDE': '3x.yaml'}}, infile_3)
     processor = DataProcessor()
     processor.include_dict.update({
-        '1.yaml': 'one',
-        '3x.yaml': [3.1, 3.14],
+        '1.yaml': 'one',  # This one overrides.
+        '3x.yaml': [3.1, 3.14],  # This one is used.
     })
     outfilename = tmp_path / 'b.yaml'
     processor.process_data(str(infilename), str(outfilename))


### PR DESCRIPTION
Include processing now searches `DataProcessor.include_dict` for matching keys to insert data, before looking at the file system. Close #6.