### PR TITLE
Use ruamel.yaml to default to YAML 1.2

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,10 +9,13 @@ yamlprocessor.dataprocess
    .. autoclass:: yamlprocessor.dataprocess.DataProcessor
       :members:
 
-   .. autoclass:: yamlprocessor.dataprocess.YpSafeDumper
-      :members:
-
    .. autoexception:: yamlprocessor.dataprocess.UnboundVariableError
+
+   .. autofunction:: yamlprocessor.dataprocess.configure_basic_logging
+
+   .. autofunction:: yamlprocessor.dataprocess.construct_yaml_timestamp
+
+   .. autofunction:: yamlprocessor.dataprocess.get_represent_datetime
 
    .. autofunction:: yamlprocessor.dataprocess.strftime_with_colon_z
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - pytest-cov
   - python-build
   - python-dateutil
-  - pyyaml
+  - ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jmespath
 jsonschema
 python-dateutil
-pyyaml
+ruamel.yaml
 sphinx
 sphinx-rtd-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     jmespath
     jsonschema
     python-dateutil
-    pyyaml
+    ruamel.yaml
 setup_require =
     pytest-runner
 tests_require =


### PR DESCRIPTION
Use Ruamel.yaml instead of PyYAML, so `yp-data` loads and dumps YAML 1.2 by default.
* Need to override date-time / timestamp constructor and representer. The default ones don't work very well with time zones.
* Otherwise, it is only about the small change to the API.