### PR TITLE
Support insertion/merging of included list/map

### DIFF
--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -104,8 +104,8 @@ Modularisation / Include with Merge
 
 A common use case for include is to merge a list read from an include
 file into the current list, (or similarly to merge a map/object read from an
-include file into the current map/object). We can tell the processor with the
-``MERGE`` keyword.
+include file into the current map/object). We can tell the processor by adding
+the ``MERGE: true`` option to the ``INCLUDE: ...`` instruction.
 
 The following example shows how to merge a list read from an include file
 into a list in place:

--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -99,6 +99,107 @@ LIMITATIONS
    recognised will not be processed.
 
 
+Modularisation / Include with Merge
+-----------------------------------
+
+A common use case for include is to merge a list read from an include
+file into the current list, (or similarly to merge a map/object read from an
+include file into the current map/object). We can tell the processor with the
+``MERGE`` keyword.
+
+The following example shows how to merge a list read from an include file
+into a list in place:
+
+.. code-block:: yaml
+
+   hello:
+     - location: Earth
+       targets:
+         - Human
+         - Dolphin
+     - INCLUDE: hello-list.yaml
+       MERGE: true
+     - location: Mars
+       targets:
+         - Martians
+
+Where ``hello-list.yaml`` contains:
+
+.. code-block:: yaml
+
+   - location: Endor
+     targets:
+       - Ewok
+       - Dulok
+   - location: Pandora
+     targets:
+       - "Na'vi"
+       - Avatar
+
+Running the processor on the first input YAML file will yield the following
+output, where the content of the include file will be inserted into the
+original list in place:
+
+.. code-block:: yaml
+
+   hello:
+     - location: Earth
+       targets:
+         - Human
+         - Dolphin
+     - location: Endor
+       targets:
+         - Ewok
+         - Dulok
+     - location: Pandora
+       targets:
+         - "Na'vi"
+         - Avatar
+     - location: Mars
+       targets:
+         - Martians
+
+The following example shows how to merge a map/object read from an include file
+into a map/object in place:
+
+.. code-block:: yaml
+
+   targets:
+     human:
+       say: Hello World
+     others:
+       INCLUDE: sayings.yaml
+       MERGE: true
+     martians:
+       say: Greeting Earthlings
+
+Where ``sayings.yaml`` contains:
+
+.. code-block:: yaml
+
+   cat:
+     say: miaow
+   dog:
+     say: woof woof
+
+Running the processor on the first input YAML file will yield the following
+output, where the content of the include file will be inserted into the
+original map/object. Note the content are inserted at the end, due to the
+associative array nature of the map/object.
+
+.. code-block:: yaml
+
+   targets:
+     human:
+       say: Hello World
+     martians:
+       say: Greeting Earthlings
+     cat:
+       say: miaow
+     dog:
+       say: woof woof
+
+
 Modularisation / Include with Query
 -----------------------------------
 

--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -184,8 +184,9 @@ Where ``sayings.yaml`` contains:
 
 Running the processor on the first input YAML file will yield the following
 output, where the content of the include file will be inserted into the
-original map/object. Note the content are inserted at the end, due to the
-associative array nature of the map/object.
+original map/object. Note: map/object keys do not have an order, so items
+from the include file will override items in the original map/object that have
+the same keys, regardless of where the items appear in the original map/object.
 
 .. code-block:: yaml
 

--- a/src/yamlprocessor/dataprocess.py
+++ b/src/yamlprocessor/dataprocess.py
@@ -221,6 +221,7 @@ class DataProcessor:
     """
 
     INCLUDE_KEY = 'INCLUDE'
+    MERGE_KEY = 'MERGE'
     QUERY_KEY = 'QUERY'
     VARIABLES_KEY = 'VARIABLES'
 
@@ -282,21 +283,57 @@ class DataProcessor:
         while stack:
             data, parent_filenames, variable_map = stack.pop()
             data = self.process_variable(data, variable_map)
-            data, parent_filenames, variable_map = self.load_include_file(
-                data, parent_filenames, variable_map)
+            if data is root:
+                # Handle INCLUDE at root level.
+                # Ignore the MERGE flag.
+                data, parent_filenames, variable_map = self.load_include_file(
+                    data, parent_filenames, variable_map)[0:3]
+            type_of_data = type(data)
             items_iter = None
-            if isinstance(data, list):
+            if type_of_data is list:
                 items_iter = enumerate(data)
-            elif isinstance(data, dict):
-                items_iter = data.items()
+            elif type_of_data is dict:
+                items_iter = data.copy().items()
             if items_iter is None:
                 continue
             for key, item in items_iter:
                 item = data[key] = self.process_variable(item, variable_map)
-                include_data, parent_filenames_x, variable_map_x = (
+                include_data, parent_filenames_x, variable_map_x, is_merge = (
                     self.load_include_file(
                         item, parent_filenames, variable_map))
-                if include_data != item:
+                if is_merge and type_of_data != type(include_data):
+                    raise TypeError()
+                if is_merge and type_of_data is list:
+                    # For a list, the iterator seems to handle the new items
+                    # perfectly fine. We insert the included list at and after
+                    # the current position. The current item is logically
+                    # replaced by the first item of the inserted list.
+                    del data[key]
+                    item = None
+                    for i, include_item in enumerate(include_data):
+                        data.insert(key + i, include_item)
+                        if i == 0:
+                            item = include_item
+                elif is_merge and type_of_data is dict:
+                    # For a dict, the iterator cannot handle size changes, so
+                    # we can only iterate over a copy of the original dict. We
+                    # insert the items in the dict normally, but we'll need to
+                    # add elements of the dict to the stack to ensure we visit
+                    # any sub-trees for include files, etc.
+                    del data[key]
+                    item = None
+                    for include_key, include_item in include_data.items():
+                        if (
+                            isinstance(include_item, dict)
+                            or isinstance(include_item, list)
+                        ):
+                            data[include_key] = include_item
+                            stack.append([
+                                include_item,
+                                parent_filenames_x,
+                                variable_map_x,
+                            ])
+                elif include_data != item:
                     item = data[key] = include_data
                 if isinstance(item, dict) or isinstance(item, list):
                     stack.append(
@@ -355,13 +392,16 @@ class DataProcessor:
         :param variable_map: :py:attr:`.variable_map` in the local scope,
                              may have additional variables.
         """
+        orig_value = value
         parent_filenames = list(parent_filenames)
         variable_map = dict(variable_map)
+        is_merge = False
         while (
             self.is_process_include
             and isinstance(value, dict)
             and self.INCLUDE_KEY in value
         ):
+            is_merge = (self.MERGE_KEY in orig_value)
             include_filename = self.process_variable(
                 value[self.INCLUDE_KEY])
             try:
@@ -378,7 +418,7 @@ class DataProcessor:
                 value = jmespath.search(value[self.QUERY_KEY], loaded_value)
             else:
                 value = loaded_value
-        return value, parent_filenames, variable_map
+        return value, parent_filenames, variable_map, is_merge
 
     @staticmethod
     def load_file(filename: str) -> object:

--- a/src/yamlprocessor/dataprocess.py
+++ b/src/yamlprocessor/dataprocess.py
@@ -15,6 +15,7 @@ Validate against specified JSON schema if root file starts with either
 """
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from contextlib import suppress
 from datetime import datetime
 from errno import ENOENT
 import logging
@@ -218,12 +219,41 @@ class DataProcessor:
        :type: str
 
        Value to substitute for unbound variables.
+
+    .. py:attribute:: .INCLUDE_SCHEMA
+       :type: dict
+
+       (Class) The schema of the INCLUDE syntax.
     """
 
     INCLUDE_KEY = 'INCLUDE'
     MERGE_KEY = 'MERGE'
     QUERY_KEY = 'QUERY'
     VARIABLES_KEY = 'VARIABLES'
+
+    INCLUDE_SCHEMA = {
+        'properties': {
+            INCLUDE_KEY: {
+                'type': 'string',
+            },
+            MERGE_KEY: {
+                'type': 'boolean',
+            },
+            QUERY_KEY: {
+                'type': 'string',
+            },
+            VARIABLES_KEY: {
+                'patternProperties': {
+                    r'^[A-z_]\w*$': {'type': 'string'},
+                },
+                'additionalProperties': False,
+                'type': 'object',
+            },
+        },
+        'additionalProperties': False,
+        'required': [INCLUDE_KEY],
+        'type': 'object',
+    }
 
     REC_SUBSTITUTE = re.compile(
         r"\A"
@@ -400,11 +430,7 @@ class DataProcessor:
         parent_filenames = list(parent_filenames)
         variable_map = dict(variable_map)
         is_merge = False
-        while (
-            self.is_process_include
-            and isinstance(value, dict)
-            and self.INCLUDE_KEY in value
-        ):
+        while self.is_process_include and self._is_include(value):
             is_merge = (self.MERGE_KEY in orig_value)
             include_filename = self.process_variable(
                 value[self.INCLUDE_KEY])
@@ -423,6 +449,20 @@ class DataProcessor:
             else:
                 value = loaded_value
         return value, parent_filenames, variable_map, is_merge
+
+    @classmethod
+    def _is_include(cls, value: object) -> bool:
+        """Return True if value is recognised as an INCLUDE syntax.
+
+        :param value: Value that may contain file name to load.
+        :return: True if value is recognised as an INCLUDE syntax.
+        """
+        if not isinstance(value, dict) or cls.INCLUDE_KEY not in value:
+            return False
+        with suppress(jsonschema.exceptions.ValidationError):
+            jsonschema.validate(schema=cls.INCLUDE_SCHEMA, instance=value)
+            return True
+        return False
 
     @staticmethod
     def load_file(filename: str) -> object:

--- a/src/yamlprocessor/dataprocess.py
+++ b/src/yamlprocessor/dataprocess.py
@@ -290,6 +290,7 @@ class DataProcessor:
                     data, parent_filenames, variable_map)[0:3]
             type_of_data = type(data)
             items_iter = None
+            skip_keys = set()
             if type_of_data is list:
                 items_iter = enumerate(data)
             elif type_of_data is dict:
@@ -297,6 +298,8 @@ class DataProcessor:
             if items_iter is None:
                 continue
             for key, item in items_iter:
+                if key in skip_keys:
+                    continue
                 item = data[key] = self.process_variable(item, variable_map)
                 include_data, parent_filenames_x, variable_map_x, is_merge = (
                     self.load_include_file(
@@ -323,11 +326,12 @@ class DataProcessor:
                     del data[key]
                     item = None
                     for include_key, include_item in include_data.items():
+                        data[include_key] = include_item
+                        skip_keys.add(include_key)
                         if (
                             isinstance(include_item, dict)
                             or isinstance(include_item, list)
                         ):
-                            data[include_key] = include_item
                             stack.append([
                                 include_item,
                                 parent_filenames_x,

--- a/src/yamlprocessor/schemaprocess.py
+++ b/src/yamlprocessor/schemaprocess.py
@@ -26,26 +26,7 @@ from .dataprocess import DataProcessor
 
 
 JSON_DUMP_CONFIG = {'indent': 2}
-INCLUDE_SCHEMA = {
-    'properties': {
-        DataProcessor.INCLUDE_KEY: {
-            'type': 'string',
-        },
-        DataProcessor.QUERY_KEY: {
-            'type': 'string',
-        },
-        DataProcessor.VARIABLES_KEY: {
-            'patternProperties': {
-                r'^[A-z_]\w*$': {'type': 'string'},
-            },
-            'additionalProperties': False,
-            'type': 'object',
-        },
-    },
-    'additionalProperties': False,
-    'required': [DataProcessor.INCLUDE_KEY],
-    'type': 'object',
-}
+INCLUDE_SCHEMA = DataProcessor.INCLUDE_SCHEMA
 INCLUDE_SCHEMA_FILENAME = 'yp-include.schema.json'
 
 

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -400,6 +400,74 @@ def test_main_11(tmp_path, yaml):
     }
 
 
+def test_main_12(tmp_path, yaml):
+    """Test main, merge include files into a list."""
+    root_data = [
+        {'name': 'cat', 'speak': ['meow', 'miaow']},
+        {'INCLUDE': 'more-farm-1.yaml', 'MERGE': True},
+        {'INCLUDE': 'more-farm-2.yaml', 'MERGE': True},
+        {'name': 'fish', 'speak': ['bubble', 'bubble']},
+    ]
+    more_data_1 = [
+        {'name': 'dog', 'speak': ['woof', 'bark']},
+        {'name': 'sheep', 'speak': ['baa', 'baa']},
+    ]
+    more_data_2 = [
+        {'name': 'duck', 'speak': ['quack', 'quack']},
+        {'name': 'farmer', 'speak': ['e-i-e-i-o']},
+    ]
+    infilename = tmp_path / 'root.yaml'
+    with infilename.open('w') as infile:
+        yaml.dump(root_data, infile)
+    include_infilename = tmp_path / 'more-farm-1.yaml'
+    with include_infilename.open('w') as infile:
+        yaml.dump(more_data_1, infile)
+    include_infilename = tmp_path / 'more-farm-2.yaml'
+    with include_infilename.open('w') as infile:
+        yaml.dump(more_data_2, infile)
+    outfilename = tmp_path / 'b.yaml'
+    main([str(infilename), str(outfilename)])
+    assert yaml.load(outfilename.open()) == [
+        {'name': 'cat', 'speak': ['meow', 'miaow']},
+        {'name': 'dog', 'speak': ['woof', 'bark']},
+        {'name': 'sheep', 'speak': ['baa', 'baa']},
+        {'name': 'duck', 'speak': ['quack', 'quack']},
+        {'name': 'farmer', 'speak': ['e-i-e-i-o']},
+        {'name': 'fish', 'speak': ['bubble', 'bubble']},
+    ]
+
+
+def test_main_13(tmp_path, yaml):
+    """Test main, merge include files into a map/object."""
+    root_data = {
+        'cat': {
+            'speak': ['meow', 'miaow'],
+            'dummy': {'INCLUDE': 'cat-data.yaml', 'MERGE': True},
+            'young': 'kitten',
+        },
+    }
+    cat_data = {
+        'chase': ['rodents', 'birds'],
+        'like': ['food', 'play'],
+    }
+    infilename = tmp_path / 'root.yaml'
+    with infilename.open('w') as infile:
+        yaml.dump(root_data, infile)
+    include_infilename = tmp_path / 'cat-data.yaml'
+    with include_infilename.open('w') as infile:
+        yaml.dump(cat_data, infile)
+    outfilename = tmp_path / 'b.yaml'
+    main([str(infilename), str(outfilename)])
+    assert yaml.load(outfilename.open()) == {
+        'cat': {
+            'speak': ['meow', 'miaow'],
+            'young': 'kitten',
+            'chase': ['rodents', 'birds'],
+            'like': ['food', 'play'],
+        },
+    }
+
+
 def test_main_validate_1(tmp_path, capsys, yaml):
     """Test main, YAML with JSON schema validation."""
     schema = {

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -444,11 +444,12 @@ def test_main_13(tmp_path, yaml):
             'speak': ['meow', 'miaow'],
             'dummy': {'INCLUDE': 'cat-data.yaml', 'MERGE': True},
             'young': 'kitten',
+            'like': ['food'],
         },
     }
     cat_data = {
         'chase': ['rodents', 'birds'],
-        'like': ['food', 'play'],
+        'like': ['food', 'play', 'sleep'],
     }
     infilename = tmp_path / 'root.yaml'
     with infilename.open('w') as infile:
@@ -463,7 +464,7 @@ def test_main_13(tmp_path, yaml):
             'speak': ['meow', 'miaow'],
             'young': 'kitten',
             'chase': ['rodents', 'birds'],
-            'like': ['food', 'play'],
+            'like': ['food', 'play', 'sleep'],
         },
     }
 


### PR DESCRIPTION
Allow insertion of elements read from a list in an include file into a list of the root file.

Ditto for insertion of key-value pairs from a map in an include file into a map of the root file.

Close #11.