### PR TITLE
Original syntax in unbound variable substitution

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install doc8 flake8 pytest pytest-cov
           python3 -m pip install -r ./requirements.txt
+          python3 -m pip install doc8 flake8 pytest pytest-cov
       - name: Install package
         run: |
           python3 -m pip install .

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -42,7 +42,9 @@ See :doc:`data-process` for detail.
 
 .. option:: --unbound-placeholder=VALUE
 
-   Substitute an unbound variable with VALUE instead of failing.
+   Substitute an unbound variable with VALUE instead of failing. Use
+   ``YP_ORIGINAL`` as VALUE to leave the original syntax unchanged on
+   unbound variables.
 
 .. option:: --no-process-include
 

--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -300,7 +300,8 @@ setting a place holder. On the command line, use the
 :option:`--unbound-placeholder=VALUE <yp-data --unbound-placeholder>`
 option. In Python, set the :py:attr:`.unbound_placeholder` attribute of the
 relevant :py:class:`yamlprocessor.dataprocess.DataProcessor` instance to a
-string value.
+string value. If you want to leave the original syntax unchanged for unbound
+variables, set the placeholder VALUE to ``YP_ORIGINAL``.
 
 
 String Value Variable Substitution Include Scope

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -252,7 +252,7 @@ def test_main_4(tmp_path, yaml):
 
 
 def test_main_5(tmp_path, yaml):
-    """Test main, process variable."""
+    """Test main, process variable, with placeholder."""
     data = ['${GREET} ${PERSON}', '${GREET} ${ALIEN}']
     infilename = tmp_path / 'a.yaml'
     with infilename.open('w') as infile:
@@ -267,6 +267,15 @@ def test_main_5(tmp_path, yaml):
         str(outfilename),
     ])
     assert yaml.load(outfilename.open()) == ['Hello Jo', 'Hello unknown']
+    main([
+        '--no-environment',
+        '-DGREET=Hello',
+        '--define=PERSON=Jo',
+        '--unbound-placeholder=' + DataProcessor.UNBOUND_ORIGINAL,
+        str(infilename),
+        str(outfilename),
+    ])
+    assert yaml.load(outfilename.open()) == ['Hello Jo', 'Hello ${ALIEN}']
 
 
 def test_main_6(tmp_path, yaml):


### PR DESCRIPTION
Allow use of a special placeholder tell YAML processor to leave original syntax for unbound variables in string value substitution.