### PR TITLE
Use the referencing library

### DIFF
--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -556,6 +556,7 @@ other_worlds:
 def test_main_validate_1(tmp_path, capsys, yaml):
     """Test main, YAML with JSON schema validation."""
     schema = {
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
         'type': 'object',
         'properties': {'hello': {'type': 'string'}},
         'required': ['hello'],


### PR DESCRIPTION
## Description

This is to avoid the `DeprecationWarning` about
*retrieving remote references being a security vulnerability*.

(We have only used this feature for referencing items in the local file system, so the software should not have been compromised. Nevertheless it is best to modify the code so we don't get this warning.)

## Impact

Expect no more deprecation warning.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
