### PR TITLE
Concat multiple input filenames before processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Python usage:
 from yamlprocessor.dataprocess import DataProcessor
 processor = DataProcessor()
 # ... Customise the `DataProcessor` instance as necessary ..., then:
-processor.process_data(in_file_name, out_file_name)
+processor.process_data([in_file_name], out_file_name)
 ```
 
 ## Documentation

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -6,7 +6,8 @@ Command line
 
 .. code-block:: bash
 
-   yp-data [options] input-file-name output-file-name
+   yp-data [options] input-file-name ... output-file-name
+   yp-data [options] -o output-file-name input-file-name ...
 
 
 Type ``yp-data --help`` for a list of options. See :doc:`cli` for detail.
@@ -19,6 +20,6 @@ Python
    from yamlprocessor.dataprocess import DataProcessor
    processor = DataProcessor()
    # ... Customise the `DataProcessor` instance as necessary ..., then:
-   processor.process_data(in_file_name, out_file_name)
+   processor.process_data([in_file_name], out_file_name)
 
 See :doc:`api` for detail.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -9,19 +9,20 @@ Usage:
 
 .. code-block:: bash
 
-   yp-data [options] input-file-name output-file-name
+   yp-data [options] input-file-name ... output-file-name
+   yp-data [options] -o output-file-name input-file-name ...
 
 See :doc:`data-process` for detail.
 
 .. program:: yp-data
 
-.. option:: input-file-name
+.. option:: file-names
 
-   Name of an input file. Use ``-`` to read from STDIN.
+   Names of input or input+output files. Use ``-`` for STDIN/STDOUT.
 
-.. option:: output-file-name
+.. option:: --out-filename=FILENAME, -o FILENAME
 
-   Name of an output file. Use ``-`` to write to STDOUT.
+   Name of output file. Use ``-`` for STDOUT.
 
 .. option:: --include=DIR, -I DIR
 

--- a/docs/data-process.rst
+++ b/docs/data-process.rst
@@ -77,7 +77,7 @@ Python logic with the above files:
    processor.include_dict.update({
        'earth.yaml': {'location': 'earth', 'targets': ['dinosaur']},
    })
-   processor.process_data('hello.yaml')
+   processor.process_data(['hello.yaml'])
 
 We'll get:
 
@@ -252,6 +252,46 @@ and the output will look like:
      targets:
        - martian
 
+
+Multiple Input Files Concatenation
+----------------------------------
+
+You can specify multiple input files in both command line and Python usages.
+The input files will be concatenated together (as text) before before parsed as
+a whole YAML document. For example, suppose we have ``part1.yaml`` with:
+
+.. code-block:: yaml
+
+   hello:
+
+And ``part2.yaml`` with:
+
+   - earth
+   - mars
+
+And ``part3.yaml`` with:
+
+   - jupiter
+   - saturn
+
+Running :program:`yp-data -o- part1.yaml part2.yaml part3.yaml` will give:
+
+.. code-block:: yaml
+
+   hello:
+   - earth
+   - mars
+   - jupiter
+   - saturn
+
+You can achieve the same results by running:
+
+.. code-block:: python
+
+   from yamlprocessor.dataprocess import DataProcessor
+   # ...
+   processor = DataProcessor()
+   processor.process_data(['part1.yaml', 'part2.yaml', 'part3.yaml'])
 
 String Value Variable Substitution
 ----------------------------------

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -598,6 +598,47 @@ def test_main_validate_1(tmp_path, capsys, yaml):
         assert f'[INFO] ok {outfilename}' in captured.err.splitlines()
 
 
+def test_main_concat_input_files(tmp_path, yaml):
+    """Test main, concatentation of multiple input files before parsing."""
+    yaml_part_1 = 'hello:\n'
+    yaml_part_2 = '- earth\n'
+    yaml_part_3 = '- mars\n'
+    infilename1 = tmp_path / 'in_1.yaml'
+    with infilename1.open('w') as infile:
+        infile.write(yaml_part_1)
+    infilename2 = tmp_path / 'in_2.yaml'
+    with infilename2.open('w') as infile:
+        infile.write(yaml_part_2)
+    infilename3 = tmp_path / 'in_3.yaml'
+    with infilename3.open('w') as infile:
+        infile.write(yaml_part_3)
+    outfilename = tmp_path / 'out.yaml'
+    # Arguments are input file names + output file name
+    main([
+        str(infilename1),
+        str(infilename2),
+        str(infilename3),
+        str(outfilename),
+    ])
+    assert yaml.load(outfilename.open()) == {'hello': ['earth', 'mars']}
+    # -o out-file-name, then arguments are only input file names
+    main([
+        '-o', str(outfilename),
+        str(infilename1),
+        str(infilename2),
+        str(infilename3),
+    ])
+    assert yaml.load(outfilename.open()) == {'hello': ['earth', 'mars']}
+    # --out-filename=out-file-name, then arguments are only input file names
+    main([
+        f'--out-filename={outfilename}',
+        str(infilename1),
+        str(infilename2),
+        str(infilename3),
+    ])
+    assert yaml.load(outfilename.open()) == {'hello': ['earth', 'mars']}
+
+
 def test_process_data_include_dict(tmp_path, yaml):
     """Test DataProcessor.process_data, with DataProcessor.include_dict."""
     data = {'testing': ['one', 2, {3: [3.1, 3.14]}]}


### PR DESCRIPTION
## Description

Support multiple input file names on the command line and Python API.
Concatenate the input file names before loading them as YAML.

## Issue(s) addressed

Relates to #25.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
