### PR TITLE
Log include, include paths, time formats, time_ref

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -27,7 +27,7 @@ See :doc:`data-process` for detail.
 .. option:: --include=DIR, -I DIR
 
    Add search locations for item specified as relative paths.
-   See also :envvar:`YP_INCLUDE_PATHS`.
+   See also :envvar:`YP_INCLUDE_PATH`.
 
 .. option:: --define=KEY=VALUE, -D KEY=VALUE
 
@@ -141,7 +141,7 @@ The following options apply to both :program:`yp-data`,
 Environment Variables
 ---------------------
 
-.. envvar:: YP_INCLUDE_PATHS
+.. envvar:: YP_INCLUDE_PATH
 
    Set the search path for include files (that are specified as relative
    locations). Expect a list of folders/directories in the same syntax as

--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - flake8
   - jmespath
   - jsonschema
-  - sphinx
-  - sphinx_rtd_theme
+  - sphinx<8
+  - sphinx_rtd_theme<3
   - pytest
   - pytest-cov
   - python-build

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ jmespath
 jsonschema
 python-dateutil
 ruamel.yaml
-sphinx
-sphinx-rtd-theme
+sphinx<8
+sphinx-rtd-theme<3

--- a/src/yamlprocessor/__init__.py
+++ b/src/yamlprocessor/__init__.py
@@ -1,2 +1,2 @@
 """Process YAML include files and variable substitutions."""
-__version__ = '0.6'
+__version__ = '0.6.1'


### PR DESCRIPTION
## Description

Log on loading include.
Log include paths, time formats and reference time value.
Fix loading from stdin. (Broken by #27.)
Fix environment variable name in docs.
Add quiet mode to avoid printing diagnostics.

## Issue(s) addressed

Resolve #29. It will now use the logger to print more diagnostic output to stderr. (Cannot use stdout, because it may be used for the actual output of the resulting YAML file.) The will be the default behaviour, but can be overridden by the `--quiet` option.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
