### PR TITLE
Add the ability to use the preprocessor with space offset

### DIFF
--- a/docs/data-preprocessor.rst
+++ b/docs/data-preprocessor.rst
@@ -3,7 +3,9 @@ Data Pre-Processor
 
 The preprocessor looks for the DIRECT_INCLUDE= keyword in the input yaml and
 concatenates the associated file at this point in the input file. The result
-is written to the output file or standard out if - is specified.
+is written to the output file or standard out if - is specified.  If the
+DIRECT_INCLUDE keyword has proceeding spaces these will be used to offset
+the lines which are being concatenated.
 
 It is expected that the keyword in the input yaml file will take the following
 format:

--- a/src/yamlprocessor/datapreprocessor.py
+++ b/src/yamlprocessor/datapreprocessor.py
@@ -49,19 +49,18 @@ class DataPreProcessor:
             # look for specific pattern in each line
             if 'DIRECT_INCLUDE=' in iline:
                 # get spaces before 'DIRECT_INCLUDE'
-                spaces = newstring.split('DIRECT_INCLUDE')[0]
+                spaces = iline.split('DIRECT_INCLUDE')[0]
                 # retrieve header file
-                yaml_header_File = iline.split('=')[1].rstrip()
+                yaml_aux_File = iline.split('=')[1].rstrip()
                 # replace variables in the string
-                yaml_header_File = self.__replace_placeholders(
-                    yaml_header_File)
-                # open header file
-                with open(yaml_header_File, 'r') as file:
-                    auxFileData = file.read()
-                # add spaces to front of lines
-                auxFileData_offset = [spaces + line for line in auxFileData]
-                # update lines for new file
-                new_line.append(auxFileData_offset)
+                yaml_aux_File = self.__replace_placeholders(
+                    yaml_aux_File)
+                # open and read header file
+                with open(yaml_aux_File, 'r') as file:
+                    auxFileData = file.readlines()
+                # Add spaces and append to output
+                for auxline in auxFileData:
+                    new_line.append(spaces + auxline)
             else:
                 new_line.append(iline)
         # save the result

--- a/src/yamlprocessor/datapreprocessor.py
+++ b/src/yamlprocessor/datapreprocessor.py
@@ -48,6 +48,8 @@ class DataPreProcessor:
         for iline in lines:
             # look for specific pattern in each line
             if 'DIRECT_INCLUDE=' in iline:
+                # get spaces before 'DIRECT_INCLUDE'
+                spaces = newstring.split('DIRECT_INCLUDE')[0]
                 # retrieve header file
                 yaml_header_File = iline.split('=')[1].rstrip()
                 # replace variables in the string
@@ -56,8 +58,10 @@ class DataPreProcessor:
                 # open header file
                 with open(yaml_header_File, 'r') as file:
                     auxFileData = file.read()
+                # add spaces to front of lines
+                auxFileData_offset = [spaces + line for line in auxFileData]
                 # update lines for new file
-                new_line.append(auxFileData)
+                new_line.append(auxFileData_offset)
             else:
                 new_line.append(iline)
         # save the result

--- a/src/yamlprocessor/tests/test_datapreprocess.py
+++ b/src/yamlprocessor/tests/test_datapreprocess.py
@@ -67,6 +67,7 @@ data:
     preprocessor.process_yaml(tmp_path / 'in_1.yaml', outfilename1)
     assert yaml.load(outfilename1.open()) == ref_yaml
 
+
 def test_main_1(tmp_path, yaml):
     """Test direct insert with spaces."""
     yaml_in = """

--- a/src/yamlprocessor/tests/test_datapreprocess.py
+++ b/src/yamlprocessor/tests/test_datapreprocess.py
@@ -66,3 +66,45 @@ data:
     outfilename1 = tmp_path / 'test_1.yaml'
     preprocessor.process_yaml(tmp_path / 'in_1.yaml', outfilename1)
     assert yaml.load(outfilename1.open()) == ref_yaml
+
+def test_main_1(tmp_path, yaml):
+    """Test direct insert with spaces."""
+    yaml_in = """
+_:
+- &banana 1
+- &groups [4, 5, 6]
+
+data:
+    brain: *banana
+    DIRECT_INCLUDE=$FILE_PATH/aux.yaml
+"""
+    yaml_aux = """
+tel: *groups
+"""
+    reference = """
+_:
+- &banana 1
+- &groups [4, 5, 6]
+
+data:
+    brain: *banana
+    tel: *groups
+"""
+    infilename = tmp_path / 'in_0.yaml'
+    with infilename.open('w') as infile:
+        infile.write(yaml_in)
+
+    auxfilename = tmp_path / 'aux.yaml'
+    with auxfilename.open('w') as auxfile:
+        auxfile.write(yaml_aux)
+
+    # Run preprocessor
+    preprocessor = DataPreProcessor()
+    keymap = {"FILE_PATH": str(tmp_path)}
+    preprocessor.add_replacements_map(keymap)
+    # Setup reference
+    ref_yaml = yaml.load(reference)
+    # Test first style input
+    outfilename0 = tmp_path / 'test_0.yaml'
+    preprocessor.process_yaml(tmp_path / 'in_0.yaml', outfilename0)
+    assert yaml.load(outfilename0.open()) == ref_yaml


### PR DESCRIPTION
## Description

The `obs bias` yaml files in the radiance yamls need to be included from jjaux because they need to just include the current active satellites.  These contain anchors which will be cleared by yp-data.  In order to allow this inclusion an ability to include the spaces before a `DIRECT_INCLUDE` is needed.  The `datapreprocessor` can then be used for this insertion.  It also makes the tool more flexible.

A slight change in name from `yaml_header_file` to `yaml_aux_file` has been made in the code to reflect this now more flexible approach.

## Issue(s) addressed

None raised

## Dependencies

None

## Impact

Additional functionality in the preprocessor

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
