### PR TITLE
Allow variable in include query value string

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.7", "3.11", "3.12"]

--- a/src/yamlprocessor/dataprocess.py
+++ b/src/yamlprocessor/dataprocess.py
@@ -523,7 +523,8 @@ class DataProcessor:
             if self.VARIABLES_KEY in value:
                 variable_map.update(value[self.VARIABLES_KEY])
             if self.QUERY_KEY in value:
-                value = jmespath.search(value[self.QUERY_KEY], loaded_value)
+                query_value = self.process_variable(value[self.QUERY_KEY])
+                value = jmespath.search(query_value, loaded_value)
             else:
                 value = loaded_value
         return value, parent_filenames, variable_map, is_merge

--- a/src/yamlprocessor/tests/test_dataprocess.py
+++ b/src/yamlprocessor/tests/test_dataprocess.py
@@ -601,6 +601,50 @@ def test_main_18(capsys, monkeypatch):
     )
 
 
+def test_main_19(tmp_path, yaml):
+    """Test main, single include with query value as variable."""
+    data_0 = {'flowers': {
+        'item1': {
+            'INCLUDE': '19i.yaml',
+            'QUERY': '${COLOUR_A}',
+            'MERGE': True,
+        },
+        'item2': {
+            'INCLUDE': '19i.yaml',
+            'QUERY': '${COLOUR_B}',
+            'MERGE': True,
+        },
+    }}
+    data_1 = {
+        'red': {'rose': 'U+1F339'},
+        'pink': {'tulip': 'U+1F337'},
+        'yellow': {'sunflower': 'U+1F33B'},
+        'white': {},
+    }
+    infilename = tmp_path / '19.yaml'
+    with infilename.open('w') as infile:
+        yaml.dump(data_0, infile)
+    with (tmp_path / '19i.yaml').open('w') as infile_1:
+        yaml.dump(data_1, infile_1)
+    outfilename = tmp_path / '19o.yaml'
+    main([
+        '-DCOLOUR_A=red',
+        '-DCOLOUR_B=yellow',
+        str(infilename),
+        str(outfilename),
+    ])
+    assert yaml.load(outfilename.open()) == {
+        'flowers': {'rose': 'U+1F339', 'sunflower': 'U+1F33B'}}
+    main([
+        '-DCOLOUR_A=white',
+        '-DCOLOUR_B=pink',
+        str(infilename),
+        str(outfilename),
+    ])
+    assert yaml.load(outfilename.open()) == {
+        'flowers': {'tulip': 'U+1F337'}}
+
+
 def test_main_validate_1(tmp_path, capsys, yaml):
     """Test main, YAML with JSON schema validation."""
     schema = {


### PR DESCRIPTION
## Description

Allow usage of string substitution variable syntax in include query values. This allows users to change an include query string using environment or CLI `-D` defined variables.

## Issue(s) addressed

Helps use case for MetOffice/jjdocs#313.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
