### PR TITLE
Raise text wrap threshold

### DIFF
--- a/src/yamlprocessor/dataprocess.py
+++ b/src/yamlprocessor/dataprocess.py
@@ -459,6 +459,7 @@ class DataProcessor:
         yaml = YAML(typ='safe', pure=True)
         yaml.default_flow_style = False
         yaml.sort_base_mapping_type_on_output = False
+        yaml.width = 4096  # prevent text wrapping for most cases
         yaml.representer.ignore_aliases = lambda data: True
         yaml.representer.add_representer(
             datetime,


### PR DESCRIPTION
## Description

Prevent most text wrap by raising dump width. For an unknown reason, previously unwrapped text has become wrapped recently, e.g.:

```diff
-                is_in: 12345, 24680, 13579, 67890, 54321, 97531, 86420, 98765, 31415
+                is_in: 12345, 24680, 13579, 67890, 54321, 97531, 86420, 98765, 
+                  31415
```

This change reduces the chance of the 2nd behaviour.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (-na-)
- [x] I have run the unit tests before creating the PR
